### PR TITLE
fix(ci): satisfy supply-chain minimumReleaseAge in lockfile

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@eslint/compat": "^2.0.5",
     "@eslint/eslintrc": "^3.3.5",
     "@eslint/js": "^10.0.1",
-    "@types/node": "^24.12.2",
+    "@types/node": "^24.12.4",
     "@typescript-eslint/parser": "^8.59.1",
     "eslint": "^10.3.0",
     "eslint-plugin-n8n-nodes-base": "^1.16.6",
@@ -59,11 +59,5 @@
   "overrides": {
     "form-data": "^4.0.4",
     "axios": "1.17.0"
-  },
-  "pnpm": {
-    "onlyBuiltDependencies": [
-      "eslint-plugin-n8n-nodes-base",
-      "isolated-vm"
-    ]
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,7 +29,7 @@ importers:
         version: 24.13.0
       '@typescript-eslint/parser':
         specifier: ^8.59.1
-        version: 8.60.1(eslint@10.4.0)(typescript@6.0.3)
+        version: 8.60.1(eslint@10.4.1)(typescript@6.0.3)
       eslint:
         specifier: ^10.3.0
         version: 10.4.1
@@ -1506,7 +1506,7 @@ snapshots:
     dependencies:
       undici-types: 7.18.2
 
-  '@typescript-eslint/parser@8.60.1(eslint@10.4.0)(typescript@6.0.3)':
+  '@typescript-eslint/parser@8.60.1(eslint@10.4.1)(typescript@6.0.3)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.60.1
       '@typescript-eslint/types': 8.60.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,8 +25,8 @@ importers:
         specifier: ^10.0.1
         version: 10.0.1(eslint@10.4.1)
       '@types/node':
-        specifier: ^24.12.2
-        version: 24.13.0
+        specifier: ^24.12.4
+        version: 24.12.4
       '@typescript-eslint/parser':
         specifier: ^8.59.1
         version: 8.60.1(eslint@10.4.1)(typescript@6.0.3)
@@ -153,8 +153,8 @@ packages:
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
 
-  '@types/node@24.13.0':
-    resolution: {integrity: sha512-5vtOqGQr4NJKeEzV441FcOi2MeG9UTWq9LqVLGneDdu4vlX17H8kQ2PA2UmNwCUGPVDj4oBjNhS7ReVEIWJJrg==}
+  '@types/node@24.12.4':
+    resolution: {integrity: sha512-GUUEShf+PBCGW2KaXwcIt3Yk+e3pkKwWKb9GSyM9WQVE+ep2jzmHdGsHzu4wgcZy5fN9FBdVzjpBQsYlpfpgLA==}
 
   '@typescript-eslint/parser@8.60.1':
     resolution: {integrity: sha512-A0M6ua6H252bVjPvvtSgl2QA4+ET9S5Mtkb2GDyTxIhH/C4qDItT7RQNO5PhMC6NXGYXOR9dIalcDDgBKT7oFA==}
@@ -1289,8 +1289,8 @@ packages:
     resolution: {integrity: sha512-tO/bf30wBbTsJ7go80j0RzA2rcwX6o7XPBpeFcb+jzoeb4pfMM2zUeSDIkY1AWqeZabWxaQZ/h8N9t35QKDLPQ==}
     engines: {node: '>=10.13.0'}
 
-  undici-types@7.18.2:
-    resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
+  undici-types@7.16.0:
+    resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
 
   upper-case-first@2.0.2:
     resolution: {integrity: sha512-514ppYHBaKwfJRK/pNC6c/OxfGa0obSnAl106u97Ed0I625Nin96KAjttZF6ZL3e1XLtphxnqrOi9iWgm+u+bg==}
@@ -1502,9 +1502,9 @@ snapshots:
 
   '@types/json-schema@7.0.15': {}
 
-  '@types/node@24.13.0':
+  '@types/node@24.12.4':
     dependencies:
-      undici-types: 7.18.2
+      undici-types: 7.16.0
 
   '@typescript-eslint/parser@8.60.1(eslint@10.4.1)(typescript@6.0.3)':
     dependencies:
@@ -2704,7 +2704,7 @@ snapshots:
       last-run: 2.0.0
       undertaker-registry: 2.0.0
 
-  undici-types@7.18.2: {}
+  undici-types@7.16.0: {}
 
   upper-case-first@2.0.2:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,12 @@
+# pnpm settings (moved out of the deprecated `pnpm` field in package.json).
+
+# Refuse to resolve/lock any package version published less than this many
+# minutes ago. Mirrors the CI supply-chain policy so `pnpm install` locally
+# picks the same compliant versions CI will accept, instead of the newest
+# release (which may still be inside the cutoff and fail --frozen-lockfile).
+minimumReleaseAge: 1440
+
+# Packages allowed to run install scripts.
+onlyBuiltDependencies:
+  - eslint-plugin-n8n-nodes-base
+  - isolated-vm

--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,6 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended"
-  ]
+  ],
+  "minimumReleaseAge": "3 days"
 }


### PR DESCRIPTION
## Problem
Every pipeline fails at `pnpm install --frozen-lockfile`:

```
[ERR_PNPM_MINIMUM_RELEASE_AGE_VIOLATION] 1 lockfile entries failed verification:
  @types/node@24.13.0 was published at 2026-06-04T07:01:50Z, within the
  minimumReleaseAge cutoff (2026-06-03T15:07:05Z)
```

Renovate (#59) bumped `@types/node` to `24.13.0`, published today. The CI
supply-chain policy rejects any lockfile entry newer than its cutoff (~1 day),
so the lockfile is non-compliant and **all** PR pipelines fail — not just one.

There was also a warning that the `pnpm` field in `package.json` is no longer
read by pnpm 10.

## Fix
- **Downgrade the offending entry**: re-resolved `@types/node` to `24.12.4`
  (published 2026-05-11), the newest version satisfying `^24.12.x` that is old
  enough to pass the policy.
- **Migrate pnpm settings to `pnpm-workspace.yaml`** (fixes the deprecation
  warning) and add `minimumReleaseAge: 1440`, so local `pnpm install` resolves
  the same compliant versions CI accepts instead of the newest release. This
  prevents the lockfile from drifting back to a too-new version.
- **Add `minimumReleaseAge: "3 days"` to renovate**, so future dependency PRs
  don't reintroduce versions that are too new for the policy (buffer over the
  ~1-day CI cutoff).

## Verification
- `pnpm install --frozen-lockfile` now passes locally with no warning and no
  policy violation.
- `npm run build` passes.
- `24.13.0` no longer appears anywhere in `pnpm-lock.yaml`.

> Note: this blocks the pipeline on every open PR (including #61). Merging this
> to `main` first will unblock the others.

🤖 Generated with [Claude Code](https://claude.com/claude-code)