### PR TITLE
fix(ci): allow build scripts on pnpm 11 (allowBuilds)

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -7,6 +7,12 @@
 minimumReleaseAge: 1440
 
 # Packages allowed to run install scripts.
+# pnpm 10 reads `onlyBuiltDependencies`; pnpm 11 renamed it to `allowBuilds`.
+# We keep both so the install passes regardless of the pnpm version CI uses
+# (the workflows pin `pnpm/action-setup` to `version: latest`).
 onlyBuiltDependencies:
   - eslint-plugin-n8n-nodes-base
   - isolated-vm
+allowBuilds:
+  eslint-plugin-n8n-nodes-base: true
+  isolated-vm: true


### PR DESCRIPTION
## Problem
With the supply-chain check now passing (#64), CI fails at the next step:

```
[ERR_PNPM_IGNORED_BUILDS] Ignored build scripts:
  eslint-plugin-n8n-nodes-base@1.16.6, isolated-vm@6.1.2
Run "pnpm approve-builds" to pick which dependencies should be allowed to run scripts.
Error: Process completed with exit code 1.
```

…for the exact two packages already listed in `onlyBuiltDependencies`.

## Root cause
The workflows pin `pnpm/action-setup` to `version: latest`, which now installs
**pnpm 11**. pnpm 11:
- renamed the build-script allowlist from `onlyBuiltDependencies` (a list) to
  **`allowBuilds`** (a map), and
- turned ignored build scripts into a **hard error** (exit 1).

pnpm 11 still *reads* `onlyBuiltDependencies` via `pnpm config get`, but no
longer **applies** it during install — so the allowlist was silently dropped
and the install aborted. (Locally this was masked: pnpm 10.33 honors
`onlyBuiltDependencies`, and a warm store reuses already-built artifacts so the
gate never triggers.)

## Fix
Provide **both** keys in `pnpm-workspace.yaml` so the install passes regardless
of which pnpm major CI resolves from `latest`:

```yaml
onlyBuiltDependencies:   # pnpm 10
  - eslint-plugin-n8n-nodes-base
  - isolated-vm
allowBuilds:             # pnpm 11
  eslint-plugin-n8n-nodes-base: true
  isolated-vm: true
```

This keeps the security gate intact (only these two trusted native/build deps
run scripts) rather than using `dangerously-allow-all-builds`.

## Verification
Fresh `pnpm install --frozen-lockfile` (clean `node_modules` + fresh store):
- pnpm **11.5.1** (CI `latest`): exit 0, no errors/warnings ✅
- pnpm **10.33.0** (local): exit 0, no errors/warnings ✅
- `isolated-vm` native build runs successfully under pnpm 11.

> Note for the future: `version: latest` is what let CI jump pnpm majors and
> break twice. Pinning `pnpm/action-setup` to a specific version (or via a
> `packageManager` field) would make CI deterministic. Left out of this PR to
> keep it minimal — happy to follow up if you want it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)