### PR TITLE
feat(docker): docker compose stack to test SMB from the n8n UI

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+# Keep the build context small. dist/ and the source are bind-mounted at
+# runtime (see docker-compose.yml), not copied into the image.
+.git
+node_modules
+dist
+.idea
+*.tsbuildinfo
+.DS_Store

--- a/Readme.md
+++ b/Readme.md
@@ -94,6 +94,58 @@ The node provides detailed error messages for common SMB issues:
 - Quota issues
 - File sharing violations
 
+## Local testing with Docker Compose
+
+A ready-to-use stack is provided to test the node from the n8n UI against a
+throwaway Samba server. It spins up two services:
+
+- **n8n** — built from `docker/Dockerfile` with the `samba-client` CLI baked in
+  (the node shells out to it) and this package auto-installed into
+  `~/.n8n/nodes` on startup.
+- **smb** — a disposable Samba server (`dperson/samba`) exposing a writable
+  share `n8nshare` for the user `n8n` / `n8npass`.
+
+```bash
+# 1. Build the node (the container loads the compiled dist/, not the .ts)
+npm run build
+
+# 2. Start the stack
+docker compose up --build
+
+# 3. Open http://localhost:5678
+```
+
+In n8n, create an **Smbclient (SMB2) API** credential with:
+
+| Field      | Value      |
+| ---------- | ---------- |
+| Server     | `smb`      |
+| Share Name | `n8nshare` |
+| User Name  | `n8n`      |
+| Password   | `n8npass`  |
+| Domain     | _(empty)_  |
+| Port       | `445`      |
+
+Then add the **SMB2 using smbclient** node and try the operations (List, Upload,
+Download, …) against the share.
+
+After changing the node code, rebuild and reinstall it into the running n8n:
+
+```bash
+npm run build
+REINSTALL_SMB_NODE=true docker compose up -d --force-recreate n8n
+```
+
+The n8n version is configurable (defaults to the latest stable 2.x):
+
+```bash
+N8N_VERSION=2.23.3 docker compose up --build
+```
+
+> n8n 2.x ships as a hardened Alpine image without a package manager, so the
+> Dockerfile installs `samba-client` in a matching Alpine stage and copies the
+> binary and its libraries into the final image.
+
 ## Running local (Development)
 
 > Required podman and n8nio image setup

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,63 @@
+name: n8n-nodes-smbclient-dev
+
+# Local stack to test the SMB2 node end-to-end from the n8n UI:
+#   - n8n: built with the samba-client CLI + this node auto-installed
+#   - smb: a throwaway Samba server with a ready-to-use share
+#
+# Usage:
+#   1. npm run build          # produce dist/ on the host
+#   2. docker compose up --build
+#   3. open http://localhost:5678 and create an "Smbclient (SMB2) API" credential:
+#        Server:     smb
+#        Share Name: n8nshare
+#        User Name:  n8n
+#        Password:   n8npass
+#        Domain:     (leave empty)
+#        Port:       445
+#
+# After editing the node code: `npm run build`, then
+#   REINSTALL_SMB_NODE=true docker compose up -d --force-recreate n8n
+
+services:
+  n8n:
+    build:
+      context: .
+      dockerfile: docker/Dockerfile
+      args:
+        N8N_VERSION: ${N8N_VERSION:-2.23.3}
+    container_name: n8n-smbclient
+    restart: unless-stopped
+    ports:
+      - "5678:5678"
+    environment:
+      - N8N_SECURE_COOKIE=false
+      - N8N_RUNNERS_ENABLED=true
+      - GENERIC_TIMEZONE=${TZ:-UTC}
+      - TZ=${TZ:-UTC}
+      # set to true to reinstall the node from /opt/code-temp on next start
+      - REINSTALL_SMB_NODE=${REINSTALL_SMB_NODE:-false}
+    volumes:
+      - n8n_data:/home/node/.n8n
+      # the built package, installed into ~/.n8n/nodes by the entrypoint
+      - ./:/opt/code-temp:ro
+    depends_on:
+      - smb
+
+  smb:
+    image: dperson/samba
+    container_name: n8n-smbclient-samba
+    restart: unless-stopped
+    # -u "user;password"
+    # -s "name;path;browseable;readonly;guest;users;admins"
+    command: >-
+      -p
+      -u "n8n;n8npass"
+      -s "n8nshare;/share;yes;no;no;n8n;n8n"
+    ports:
+      - "1445:445" # host:container — only needed to inspect the share from the host
+    volumes:
+      - smb_data:/share
+
+volumes:
+  n8n_data:
+  smb_data:

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,44 @@
+# n8n image preloaded with the samba-client CLI that n8n-nodes-smbclient
+# shells out to. The community node itself is installed at startup by
+# entrypoint.sh from the source mounted at /opt/code-temp.
+#
+# n8n 2.x ships as a Docker Hardened Image (Alpine, no package manager), so we
+# can't `apk add` directly. Instead we install samba-client in a matching plain
+# Alpine and copy the resulting files (smbclient + its dependency libraries)
+# into the final image.
+
+# Declared before the first FROM so it can be used in the stage-2 FROM line.
+ARG N8N_VERSION=2.23.3
+
+# ---- Stage 1: collect smbclient + its dependency files ----
+FROM alpine:3.22 AS smb
+RUN set -eux; \
+	apk add --no-cache samba-client 2>&1 | tee /tmp/apk.log; \
+	smbclient --version; \
+	mkdir -p /export; \
+	# Copy every file owned by samba-client and the packages it pulled in.
+	# Base Alpine packages (musl, etc.) are already in the hardened image, so
+	# they never appear in the "Installing" lines and aren't copied/clobbered.
+	for p in $(grep -oE 'Installing [^ ]+' /tmp/apk.log | awk '{print $2}'); do \
+		apk info -L "$p" | grep -E '^(usr/|lib/|etc/)' | while read -r f; do \
+			[ -e "/$f" ] || continue; \
+			mkdir -p "/export/$(dirname "$f")"; \
+			cp -a "/$f" "/export/$f"; \
+		done; \
+	done
+
+# ---- Stage 2: n8n + smbclient ----
+FROM n8nio/n8n:${N8N_VERSION}
+
+USER root
+
+COPY --from=smb /export/ /
+# Fail the build early if smbclient can't run (missing lib, etc.).
+RUN smbclient --version
+
+COPY docker/entrypoint.sh /usr/local/bin/smbclient-node-entrypoint.sh
+RUN chmod +x /usr/local/bin/smbclient-node-entrypoint.sh
+
+USER node
+
+ENTRYPOINT ["tini", "--", "/usr/local/bin/smbclient-node-entrypoint.sh"]

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,31 @@
+#!/bin/sh
+# Installs the locally-built n8n-nodes-smbclient package (mounted at
+# /opt/code-temp) into n8n's user nodes directory, then starts n8n.
+#
+# The host must run `npm run build` (or `pnpm build`) first so that
+# /opt/code-temp/dist exists — n8n loads the compiled files, not the .ts.
+set -e
+
+SOURCE_DIR="/opt/code-temp"
+NODES_DIR="/home/node/.n8n/nodes"
+PKG_NAME="n8n-nodes-smbclient"
+
+if [ ! -d "$SOURCE_DIR/dist" ]; then
+	echo "WARNING: $SOURCE_DIR/dist not found."
+	echo "         Run 'npm run build' on the host, then restart this container."
+fi
+
+mkdir -p "$NODES_DIR"
+cd "$NODES_DIR"
+
+[ -f package.json ] || echo '{"name":"installed-nodes","private":true}' >package.json
+
+if [ ! -d "node_modules/$PKG_NAME" ] || [ "${REINSTALL_SMB_NODE:-false}" = "true" ]; then
+	echo "Installing $PKG_NAME from $SOURCE_DIR ..."
+	npm install "$SOURCE_DIR" --no-audit --no-fund --loglevel error
+else
+	echo "$PKG_NAME already installed (set REINSTALL_SMB_NODE=true to refresh after a rebuild)."
+fi
+
+# Hand off to n8n's own entrypoint.
+exec /docker-entrypoint.sh "$@"


### PR DESCRIPTION
## Summary
Adds a ready-to-use local stack to test the SMB2 node end-to-end from the n8n
UI, against a throwaway Samba server. Defaults to the **latest stable n8n 2.x**.

```bash
npm run build
docker compose up --build
# open http://localhost:5678
```

## What's included
- **`docker/Dockerfile`** — n8n image with the `samba-client` CLI the node
  shells out to. n8n 2.x ships as a **Docker Hardened Image** (Alpine, no
  package manager), so `apk add` no longer works; instead `samba-client` is
  installed in a matching `alpine:3.22` stage and its binary + dependency
  libraries are copied into the final image. The build runs `smbclient
  --version` to fail fast if a library is missing.
- **`docker/entrypoint.sh`** — installs the locally-built package into
  `~/.n8n/nodes` on startup (the container loads the compiled `dist/`), then
  hands off to n8n's own entrypoint. Set `REINSTALL_SMB_NODE=true` to refresh
  after a rebuild.
- **`docker-compose.yml`** — the `n8n` service plus a disposable
  `dperson/samba` server exposing a writable share.
- **`.dockerignore`** + a **Readme** section documenting the workflow and the
  credential values.

## Credential to use in n8n
| Field | Value |
| ----- | ----- |
| Server | `smb` |
| Share Name | `n8nshare` |
| User Name | `n8n` |
| Password | `n8npass` |
| Domain | _(empty)_ |
| Port | `445` |

## Verification
Brought the stack up on **n8n 2.23.3**:
- `smbclient 4.21.9` present in the n8n container ✅
- node `dist` installed into `~/.n8n/nodes` and loaded without errors ✅
- n8n `/healthz` returns 200 ✅
- upload + list round-trip from the n8n container to the share succeeds ✅

Override the version with `N8N_VERSION=… docker compose up --build`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)