### PR TITLE
fix(docker): force LF line endings on entrypoint.sh

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+# Shell scripts must keep LF endings, otherwise the CRLF shebang breaks
+# `exec` inside Linux/Docker ("No such file or directory"). This matters on
+# Windows checkouts where core.autocrlf would otherwise rewrite them.
+*.sh text eol=lf
+docker/entrypoint.sh text eol=lf


### PR DESCRIPTION
## Problem

On Windows checkouts, `docker/entrypoint.sh` ended up with CRLF line endings. That turns the shebang into `#!/bin/sh\r`, so the container fails at startup:

```
[FATAL tini (7)] exec /usr/local/bin/smbclient-node-entrypoint.sh failed: No such file or directory
```

The kernel tries to exec an interpreter literally named `/bin/sh<CR>`, which doesn't exist. It worked on macOS because the file stayed LF there.

## Fix

Add a `.gitattributes` rule forcing `*.sh` (and the entrypoint explicitly) to `eol=lf`, so shell scripts keep LF endings on every platform and the CRLF regression can't recur on Windows checkouts.

## Testing

- `file docker/entrypoint.sh` now reports a clean POSIX shell script (no CRLF).
- `docker compose up --build` starts the container without the exec failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)