### PR TITLE
fix(ci): read bumped version from package.json, not pnpm output

### DIFF
--- a/.github/workflows/one-shot-npm-publish.yml
+++ b/.github/workflows/one-shot-npm-publish.yml
@@ -49,9 +49,12 @@ jobs:
       - name: Set version
         id: bump
         run: |
-          NEW_VERSION=$(pnpm version "${{ inputs.version }}" --no-git-tag-version | tail -n1)
-          echo "version=${NEW_VERSION}" >> "$GITHUB_OUTPUT"
-          echo "Releasing ${NEW_VERSION}"
+          # `pnpm version` prints a human message ("Releasing pkg: x → y"), not
+          # the bare version, so read the result back from package.json instead.
+          pnpm version "${{ inputs.version }}" --no-git-tag-version
+          NEW_VERSION=$(node -p "require('./package.json').version")
+          echo "version=v${NEW_VERSION}" >> "$GITHUB_OUTPUT"
+          echo "Releasing v${NEW_VERSION}"
 
       # Commit the bump and tag it, then push both back to the triggering branch.
       # NOTE: this pushes directly to the branch the workflow ran on. If that


### PR DESCRIPTION
## Problem

The release workflow failed at the tag step:

```
fatal: 'n8n-nodes-smbclient: 1.1.2 → 1.1.3' is not a valid tag name.
Error: Process completed with exit code 128.
```

`pnpm version` prints a human-readable message (`Releasing n8n-nodes-smbclient: 1.1.2 → 1.1.3`) rather than the bare `v1.1.3` that `npm version` emits, so `tail -n1` captured the whole sentence and it was used verbatim as the tag.

## Fix

Read the new version back from `package.json` after the bump and prefix it with `v`:

```bash
pnpm version "${{ inputs.version }}" --no-git-tag-version
NEW_VERSION=$(node -p "require('./package.json').version")
echo "version=v${NEW_VERSION}" >> "$GITHUB_OUTPUT"
```

The failed run errored *before* pushing or publishing, so `main` and npm were untouched (npm still at 1.1.2). After merge, re-run with version `1.1.3`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)